### PR TITLE
Fix typo in LZW compression function docstrings

### DIFF
--- a/src/lzw.lisp
+++ b/src/lzw.lisp
@@ -8,11 +8,11 @@
 ;;; LZW (Lempel-Ziv-Welch) compression algorithm
 
 (defun compress-file (file out-file)
-  "Compresses a file into an LWZ encoded file."
+  "Compresses a file into an LZW encoded file."
   (write-bytes-to-file (compress (read-file-bytes-to-list file 8)) out-file 16))
 
 (defun decompress-file (file out-file)
-  "Decompresses an encoded LWZ file."
+  "Decompresses an encoded LZW file."
   (write-bytes-to-file (decompress (read-file-bytes-to-list file 16)) out-file 8))
 
 ;;; Takes a list of bytes and encodes them into compressed LZW format


### PR DESCRIPTION
## Summary
Corrected typos in the docstrings for the LZW compression and decompression functions where "LWZ" was incorrectly spelled instead of "LZW".

## Changes
- Fixed docstring in `compress-file` function: "LWZ encoded" → "LZW encoded"
- Fixed docstring in `decompress-file` function: "LWZ file" → "LZW file"

## Details
These were simple documentation corrections to ensure the docstrings accurately reflect the algorithm name (Lempel-Ziv-Welch, abbreviated as LZW) rather than the misspelled variant.

https://claude.ai/code/session_01NMWm626YdufWEpHDse7nkh